### PR TITLE
remove no resolver warnings from newer version of GraphQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ Sample output:
 ```
 brokenQuery query has the following validation errors:
 
-🛑  Field "episodeID" must not have a selection since type "Int" has no subfields.
+⯃  Field "episodeID" must not have a selection since type "Int" has no subfields.
    Locations: [{"line":5,"column":17}]
 
-🛑  Cannot query field "field_does_not_exist" on type "Film".
+⯃  Cannot query field "field_does_not_exist" on type "Film".
    Locations: [{"line":10,"column":7}]
 
-🛑  Field "speciesConnection" of type "FilmSpeciesConnection" must have a selection of subfields. Did you mean "speciesConnection { ... }"?
+⯃  Field "speciesConnection" of type "FilmSpeciesConnection" must have a selection of subfields. Did you mean "speciesConnection { ... }"?
    Locations: [{"line":12,"column":7}]
 ```
 
@@ -56,10 +56,10 @@ Sample output:
 ```
 query speciesByFilm has the following deprecation warnings:
 
-🛑  The field Film.species is deprecated. Test, use speciesConnection
+⯃  The field Film.species is deprecated. Test, use speciesConnection
     Locations: [{"line":7,"column":7}]
 
-🛑  The field Film.planets is deprecated. Test, use planetConnection
+⯃  The field Film.planets is deprecated. Test, use planetConnection
     Locations: [{"line":8,"column":7}]
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,23 +1,18 @@
 #!/usr/bin/env node
 
-const dotenv = require('dotenv'),
-      chalk = require('chalk'),
-      app = require('commander'),
-      resolvePath = require('path').resolve,
-      stderr = new console.Console(process.stderr);
-
-dotenv.config();
-
+const dotenv = require('dotenv');
+const chalk = require('chalk');
+const app = require('commander');
+const { resolve: resolvePath } = require('path');
 const Schema = require('./lib/schema');
 
-const oneMoment = () => {
-  stderr.log(chalk.yellow("one moment please...\n"));
-};
+const stderr = new console.Console(process.stderr);
+dotenv.config();
 
-const getSchemaAndQueryies = (schema_file, query_file) => {
+const getSchemaAndQueries = (schema_file, query_file) => {
   const schema = require('./lib/schema').fromFile(resolvePath(schema_file));
   const query = require('./lib/query').fromFile(resolvePath(query_file));
-  return {schema, query};
+  return { schema, query };
 }
 
 app.command('get-schema [graphql_endpoint]').description('Fetch a GraphQL schema as a file.').option('--json', 'output in json format').action(async (graphql_endpoint, {json}) => {
@@ -27,32 +22,29 @@ app.command('get-schema [graphql_endpoint]').description('Fetch a GraphQL schema
 });
 
 app.command('deprecation-check <schema_file> <query_file>').description(`Check a single query against a local schema for ${chalk.yellow('deprecation')} warnings`).action(async (schema_file, query_file) => {
-  oneMoment();
-  const sq = getSchemaAndQueryies(schema_file, query_file);
+  const sq = getSchemaAndQueries(schema_file, query_file);
   console.log(await require('./lib/deprecation').reportForQuery(sq.schema, sq.query));
 });
 
 app.command('validation-check <schema_file> <query_file>').description(`Check a single query against a local schema for ${chalk.yellow('validation')} warnings`).action(async (schema_file, query_file) => {
-  oneMoment();
-  const sq = getSchemaAndQueryies(schema_file, query_file);
+  const sq = getSchemaAndQueries(schema_file, query_file);
   console.log(await require('./lib/validation').reportForQuery(sq.schema, sq.query));
 });
 
 app.command('check-query <schema_file> <query_file>').description(`Check a single query for ${chalk.yellow('validation')} and ${chalk.yellow('deprecation')} errors`).action(async (schema_file, query_file) => {
-  oneMoment();
-  const sq = getSchemaAndQueryies(schema_file, query_file);
-  const output = [];
-  output.push(await require('./lib/validation').reportForQuery(sq.schema, sq.query));
-  output.push(await require('./lib/deprecation').reportForQuery(sq.schema, sq.query));
+  const sq = getSchemaAndQueries(schema_file, query_file);
+  const output = await Promise.all([
+    require('./lib/validation').reportForQuery(sq.schema, sq.query),
+    require('./lib/deprecation').reportForQuery(sq.schema, sq.query),
+  ]);
   console.log(output.join("\n").trim());
 });
 
 app.command('json-to-graphql <json_schema_file>').action(async (json_schema_file) => {
-  oneMoment();
   console.log(Schema.printIDL(Schema.fromFile(resolvePath(json_schema_file))));
 });
 
-app.version('0.2').parse(process.argv);
+app.version('0.3').parse(process.argv);
 
 if (!process.argv.slice(2).length) {
   app.outputHelp();

--- a/lib/deprecation.js
+++ b/lib/deprecation.js
@@ -1,49 +1,40 @@
 /* jslint node: true */
 
-const P = require('bluebird'),
-      R = require('ramda'),
-      findDeprecatedUsage = require('graphql/utilities/findDeprecatedUsages').findDeprecatedUsages,
-      parse = require('graphql/language/parser').parse,
-      isBlank = (x) => R.isNil(x) || R.isEmpty(x),
-      getOperationNameFromQuery = require('./operation_name').getOperationNameFromQuery,
-      chalk = require('chalk'),
-      alertSymbol = "🛑  ";
+const R = require('ramda');
+const chalk = require('chalk');
+const { parse } = require('graphql/language/parser');
+const { findDeprecatedUsages } = require('graphql/utilities/findDeprecatedUsages');
+const { getOperationNameFromQuery } = require('./operation_name');
 
-const getDeprecateionWarnings = async (schema, query) => {
+const isBlank = (x) => R.isNil(x) || R.isEmpty(x);
+const alertSymbol = "⯃  ";
+
+const getDeprecationWarnings = async (schema, query) => {
   try {
-    const parsedQuery = parse(query);
-    return findDeprecatedUsage(schema, parsedQuery);
+    return findDeprecatedUsages(schema, parse(query));
   } catch (e) {
     return null;
   }
 };
 
-const outputReportLine = (message) => {
-  const line = [message.message];
-  line.push("    Locations: " + JSON.stringify(message.locations));
-  return line.join("\n");
-};
+const outputReportLine = message =>
+  `${message.message}  Locations: ${JSON.stringify(message.locations)}`;
 
-const outputReport = async ({clientID, query, messages}) => {
+const outputReport = async ({ query, messages }) => {
   const op = getOperationNameFromQuery(query);
-  const line = [];
 
-  line.push(!R.isNil(op) ? 'query ' + chalk.green(op) : 'unknown query');
-
-  if (clientID)
-    line.push(` for client ${chalk.yellow(clientID)}`);
-
-  line.push(" has the following deprecation warnings:\n\n");
-  line.push(alertSymbol + R.map(outputReportLine, messages).join("\n\n" + alertSymbol) + "\n");
-  return line.join("");
+  return [
+    !R.isNil(op) ? 'query ' + chalk.green(op) : 'query',
+    " has the following deprecation warnings:\n\n",
+    alertSymbol + R.map(outputReportLine, messages).join("\n\n" + alertSymbol) + "\n"
+  ].join('');
 };
 
 const reportForQuery = async (schema, query) => {
-  const messages = await getDeprecateionWarnings(schema, query);
-  return !R.isEmpty(messages) ? outputReport({query, messages}) : '';
-}
+  const messages = await getDeprecationWarnings(schema, query);
+  return !isBlank(messages) ? outputReport({ query, messages }) : '';
+};
 
 module.exports = {
   reportForQuery,
-  getDeprecateionWarnings
 };

--- a/lib/operation_name.js
+++ b/lib/operation_name.js
@@ -2,8 +2,9 @@
 
 module.exports = {
   getOperationNameFromQuery: (query) => {
-    if (!query)
+    if (!query) {
       return null;
+    }
     const match = query.match(/^query\s(\w+)\s*?/);
     return match ? match[1] : null;
   }

--- a/lib/query.js
+++ b/lib/query.js
@@ -2,10 +2,6 @@
 
 const fs = require('fs');
 
-const fromFile = (path) => {
-  return fs.readFileSync(path).toString();
-};
-
 module.exports = {
-  fromFile
+  fromFile: path => fs.readFileSync(path).toString(),
 };

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,33 +1,32 @@
 /* jslint node: true */
 
-const P = require('bluebird'),
-      fs = require('fs');
+const request = require('request-promise');
+const fs = require('fs');
+const { introspectionQuery } = require('graphql/utilities/introspectionQuery');
+const { makeExecutableSchema } = require('graphql-tools');
+const { buildClientSchema } = require('graphql/utilities/buildClientSchema');
+const { printSchema } = require('graphql/utilities/schemaPrinter');
 
-const downloadJSONSchema = (graphQlUrl) => {
-  const request = require('request'),
-        requestAsync = P.promisify(request),
-        introspectionQuery = require('graphql/utilities/introspectionQuery').introspectionQuery;
+const downloadJSONSchema = graphQlUrl => request(
+  graphQlUrl || process.env.GRAPHQL_URL,
+  {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: introspectionQuery }),
+    json: true,
+  }
+).then(({ data }) => data);
 
-  return requestAsync(graphQlUrl || process.env.GRAPHQL_URL, {method: 'POST', headers: {'Content-Type': 'application/json',}, body: JSON.stringify({query: introspectionQuery}),}).then(resp => {
-    return JSON.parse(resp.body).data;
-  });
-};
+const getSchema = graphQlUrl => downloadJSONSchema(graphQlUrl).then(jsonToSchema);
 
-const getSchema = (graphQlUrl) => {
-  return downloadJSONSchema(graphQlUrl).then(jsonToSchema);
-};
+const jsonToGraphQL = jsonSchema => printIDL(jsonToSchema(jsonSchema));
 
-const jsonToGraphQL = (jsonSchema) => {
-  return printIDL(jsonToSchema(jsonSchema));
-};
+const jsonToSchema = buildClientSchema;
 
-const jsonToSchema = (jsonSchema) => {
-  return require('graphql/utilities/buildClientSchema').buildClientSchema(jsonSchema);
-}
-
-const graphqlToSchema = (idlSchema) => {
-  return require('graphql-tools').makeExecutableSchema({typeDefs: idlSchema});
-}
+const graphqlToSchema = typeDefs => makeExecutableSchema({
+  typeDefs,
+  resolverValidationOptions: { requireResolversForResolveType: false },
+});
 
 const fromFile = (path) => {
   const contents = fs.readFileSync(path).toString();
@@ -36,9 +35,7 @@ const fromFile = (path) => {
   return graphqlToSchema(contents);
 };
 
-const printIDL = (schema) => {
-  return require('graphql/utilities/schemaPrinter').printSchema(schema, {commentDescriptions: true});
-};
+const printIDL = schema => printSchema(schema, { commentDescriptions: true });
 
 module.exports = {
   getSchema,

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -7,7 +7,7 @@ const graphql = require('graphql'),
 
 const getErrorMessage = (error) => {
   const output = [];
-  output.push("🛑  " + error.message);
+  output.push("⯃  " + error.message);
   output.push("   Locations: " + JSON.stringify(error.locations));
   output.push("");
   return output.join("\n");

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,32 +4,718 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/zen-observable": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.5.3.tgz",
-      "integrity": "sha512-aDvGDAHcVfUqNmd8q4//cHAP+HGxsbChbBbuk3+kMVk5TTxfWLpQWvVN3+UPjohLnwMYN7jr6BWNn2cYNqdm7g=="
-    },
-    "acorn": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
-      "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
-      "dev": true
-    },
-    "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+    "@babel/code-frame": {
+      "version": "7.5.5",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.5.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha1-VtETEr2SSPphlZHQJHK+boyzJUA=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+          "dev": true
+        }
+      }
+    },
+    "@hapi/address": {
+      "version": "2.1.2",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@hapi/address/-/address-2.1.2.tgz",
+      "integrity": "sha1-HHlM1tvyNU0ese8Q4DA/Vz4cciI=",
+      "dev": true
+    },
+    "@hapi/boom": {
+      "version": "7.4.11",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@hapi/boom/-/boom-7.4.11.tgz",
+      "integrity": "sha1-N6+EF+uUFq7zNnqmD6BKGp8fwmI=",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/bossy": {
+      "version": "4.1.3",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@hapi/bossy/-/bossy-4.1.3.tgz",
+      "integrity": "sha1-xADW3Dq8BfG8KX6l+nezN7tMWYg=",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x"
+      }
+    },
+    "@hapi/eslint-config-hapi": {
+      "version": "12.3.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@hapi/eslint-config-hapi/-/eslint-config-hapi-12.3.0.tgz",
+      "integrity": "sha1-WqAyVgwdsMyA7XeieTpwYN2h/wg=",
+      "dev": true
+    },
+    "@hapi/eslint-plugin-hapi": {
+      "version": "4.3.4",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@hapi/eslint-plugin-hapi/-/eslint-plugin-hapi-4.3.4.tgz",
+      "integrity": "sha1-mnQmUPB5BS+XFsLg8EnvXcV9A8c=",
+      "dev": true,
+      "requires": {
+        "@hapi/rule-capitalize-modules": "1.x.x",
+        "@hapi/rule-for-loop": "1.x.x",
+        "@hapi/rule-no-arrowception": "1.x.x",
+        "@hapi/rule-no-var": "1.x.x",
+        "@hapi/rule-scope-start": "2.x.x"
+      }
+    },
+    "@hapi/formula": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@hapi/formula/-/formula-1.2.0.tgz",
+      "integrity": "sha1-mUZJx/6hqQuRoKHm2YNSP2gOEM0=",
+      "dev": true
+    },
+    "@hapi/hoek": {
+      "version": "8.5.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@hapi/hoek/-/hoek-8.5.0.tgz",
+      "integrity": "sha1-L5zjAciJjhwySLCoVkaWsk0amlo=",
+      "dev": true
+    },
+    "@hapi/joi": {
+      "version": "16.1.7",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@hapi/joi/-/joi-16.1.7.tgz",
+      "integrity": "sha1-NghXIjqHux9fZ2kVN5ZMG0kI7ZM=",
+      "dev": true,
+      "requires": {
+        "@hapi/address": "^2.1.2",
+        "@hapi/formula": "^1.2.0",
+        "@hapi/hoek": "^8.2.4",
+        "@hapi/pinpoint": "^1.0.2",
+        "@hapi/topo": "^3.1.3"
+      }
+    },
+    "@hapi/lab": {
+      "version": "21.0.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@hapi/lab/-/lab-21.0.0.tgz",
+      "integrity": "sha1-qLoFbSfGDtj53zRm3Ig6cVMGN0I=",
+      "dev": true,
+      "requires": {
+        "@hapi/bossy": "4.x.x",
+        "@hapi/eslint-config-hapi": "12.x.x",
+        "@hapi/eslint-plugin-hapi": "4.x.x",
+        "@hapi/hoek": "8.x.x",
+        "diff": "4.x.x",
+        "eslint": "6.x.x",
+        "espree": "6.x.x",
+        "find-rc": "4.x.x",
+        "globby": "10.x.x",
+        "handlebars": "4.x.x",
+        "mkdirp": "0.5.x",
+        "seedrandom": "3.x.x",
+        "source-map": "0.7.x",
+        "source-map-support": "0.5.x",
+        "supports-color": "7.x.x",
+        "typescript": "3.6.x",
+        "will-call": "1.x.x"
       },
       "dependencies": {
         "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "version": "7.1.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/acorn/-/acorn-7.1.0.tgz",
+          "integrity": "sha1-lJ028sKSU12mAig1hsJHfFfrLWw=",
           "dev": true
+        },
+        "acorn-jsx": {
+          "version": "5.1.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+          "integrity": "sha1-KUrbcbVzmLBoABXwo4xWPuHbU4Q=",
+          "dev": true
+        },
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha1-086gTWsBeyiUrWkED+yLYj60vVI=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-escapes": {
+          "version": "4.2.1",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+          "integrity": "sha1-TczbhGw+7hD21k3qZic+q5DDcig=",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.5.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "dev": true
+        },
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha1-t5hCCtvrHego2ErNii4j0+/oXo0=",
+          "dev": true
+        },
+        "chardet": {
+          "version": "0.7.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/chardet/-/chardet-0.7.0.tgz",
+          "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4=",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha1-JkMFp65JDR0Dvwybp8kl0XU68wc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "diff": {
+          "version": "4.0.1",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha1-DGZ8tGfru1zqfxTxNcwtuneAqP8=",
+          "dev": true
+        },
+        "doctrine": {
+          "version": "3.0.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/doctrine/-/doctrine-3.0.0.tgz",
+          "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "eslint": {
+          "version": "6.6.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/eslint/-/eslint-6.6.0.tgz",
+          "integrity": "sha1-SgGi+0jTKqzvVTDunFp48RqK/QQ=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "ajv": "^6.10.0",
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^4.0.1",
+            "doctrine": "^3.0.0",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^1.4.3",
+            "eslint-visitor-keys": "^1.1.0",
+            "espree": "^6.1.2",
+            "esquery": "^1.0.1",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^5.0.1",
+            "functional-red-black-tree": "^1.0.1",
+            "glob-parent": "^5.0.0",
+            "globals": "^11.7.0",
+            "ignore": "^4.0.6",
+            "import-fresh": "^3.0.0",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^7.0.0",
+            "is-glob": "^4.0.0",
+            "js-yaml": "^3.13.1",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.14",
+            "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "progress": "^2.0.0",
+            "regexpp": "^2.0.1",
+            "semver": "^6.1.2",
+            "strip-ansi": "^5.2.0",
+            "strip-json-comments": "^3.0.1",
+            "table": "^5.2.3",
+            "text-table": "^0.2.0",
+            "v8-compile-cache": "^2.0.3"
+          }
+        },
+        "eslint-scope": {
+          "version": "5.0.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/eslint-scope/-/eslint-scope-5.0.0.tgz",
+          "integrity": "sha1-6HyIh8c+jR7ITxylkWRcNYv8j7k=",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "espree": {
+          "version": "6.1.2",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/espree/-/espree-6.1.2.tgz",
+          "integrity": "sha1-bCcmUJMrT5HDcU5ee19eLs9HJi0=",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.1.0",
+            "acorn-jsx": "^5.1.0",
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "esquery": {
+          "version": "1.0.1",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/esquery/-/esquery-1.0.1.tgz",
+          "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
+          "dev": true,
+          "requires": {
+            "estraverse": "^4.0.0"
+          }
+        },
+        "external-editor": {
+          "version": "3.1.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/external-editor/-/external-editor-3.1.0.tgz",
+          "integrity": "sha1-ywP3QL764D6k0oPK7SdBqD8zVJU=",
+          "dev": true,
+          "requires": {
+            "chardet": "^0.7.0",
+            "iconv-lite": "^0.4.24",
+            "tmp": "^0.0.33"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "figures": {
+          "version": "3.1.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/figures/-/figures-3.1.0.tgz",
+          "integrity": "sha1-SxmN0H2NcVMGQoZK8tRd2eRZxOw=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "file-entry-cache": {
+          "version": "5.0.1",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+          "integrity": "sha1-yg9u+m3T1WEzP7FFFQZcL6/fQ5w=",
+          "dev": true,
+          "requires": {
+            "flat-cache": "^2.0.1"
+          }
+        },
+        "find-rc": {
+          "version": "4.0.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/find-rc/-/find-rc-4.0.0.tgz",
+          "integrity": "sha1-meQ8Wgx16dOIfSHssx73SSNXKqM=",
+          "dev": true
+        },
+        "flat-cache": {
+          "version": "2.0.1",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/flat-cache/-/flat-cache-2.0.1.tgz",
+          "integrity": "sha1-XSltbwS9pEpGMKMBQTvbwuwIXsA=",
+          "dev": true,
+          "requires": {
+            "flatted": "^2.0.0",
+            "rimraf": "2.6.3",
+            "write": "1.0.3"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
+          "dev": true
+        },
+        "globby": {
+          "version": "10.0.1",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/globby/-/globby-10.0.1.tgz",
+          "integrity": "sha1-R4LDTLdd1oM1EzXFgpzDQg5gayI=",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.0.3",
+            "glob": "^7.1.3",
+            "ignore": "^5.1.1",
+            "merge2": "^1.2.3",
+            "slash": "^3.0.0"
+          },
+          "dependencies": {
+            "ignore": {
+              "version": "5.1.4",
+              "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/ignore/-/ignore-5.1.4.tgz",
+              "integrity": "sha1-hLez2+ZFUrbvDsqZ9nQ9vsbZet8=",
+              "dev": true
+            }
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "7.0.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/inquirer/-/inquirer-7.0.0.tgz",
+          "integrity": "sha1-nisDLd532h2124BHWLj+o6lwUZo=",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^3.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mute-stream": "0.0.8",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.4.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^5.1.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.8",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/mute-stream/-/mute-stream-0.0.8.tgz",
+          "integrity": "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha1-//DzyRYX/mK7UBiWNumayKbfe+U=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha1-OfZ8VLOnpYzqUjbZXPADQjljH34=",
+          "dev": true,
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "seedrandom": {
+          "version": "3.0.5",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/seedrandom/-/seedrandom-3.0.5.tgz",
+          "integrity": "sha1-VO3IXJUiJSWwx6b2s1Q9jgs6oKc=",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/slice-ansi/-/slice-ansi-2.1.0.tgz",
+          "integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "astral-regex": "^1.0.0",
+            "is-fullwidth-code-point": "^2.0.0"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M=",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.16",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/source-map-support/-/source-map-support-0.5.16.tgz",
+          "integrity": "sha1-CuBp5/47p1OMZMmFFeNTOerFoEI=",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+              "dev": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "4.1.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/string-width/-/string-width-4.1.0.tgz",
+          "integrity": "sha1-uoRtHaqXw8WWFVMIBj4HXtHJmv8=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^5.2.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "table": {
+          "version": "5.4.6",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/table/-/table-5.4.6.tgz",
+          "integrity": "sha1-EpLRlQDOP4YFOwXw6Ofko7shB54=",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.10.2",
+            "lodash": "^4.17.14",
+            "slice-ansi": "^2.1.0",
+            "string-width": "^3.0.0"
+          },
+          "dependencies": {
+            "emoji-regex": {
+              "version": "7.0.3",
+              "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/emoji-regex/-/emoji-regex-7.0.3.tgz",
+              "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "3.1.0",
+              "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/string-width/-/string-width-3.1.0.tgz",
+              "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            }
+          }
+        },
+        "write": {
+          "version": "1.0.3",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/write/-/write-1.0.3.tgz",
+          "integrity": "sha1-CADhRSO5I6OH5BUSPIZWFqrg9cM=",
+          "dev": true,
+          "requires": {
+            "mkdirp": "^0.5.1"
+          }
         }
+      }
+    },
+    "@hapi/pinpoint": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+      "integrity": "sha1-Alt6Ntu/TTW/Gs0HHCayDvQeDRM=",
+      "dev": true
+    },
+    "@hapi/rule-capitalize-modules": {
+      "version": "1.2.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@hapi/rule-capitalize-modules/-/rule-capitalize-modules-1.2.1.tgz",
+      "integrity": "sha1-cmicMMDVmuDj2ECWDeFbGuNXPPc=",
+      "dev": true
+    },
+    "@hapi/rule-for-loop": {
+      "version": "1.2.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@hapi/rule-for-loop/-/rule-for-loop-1.2.1.tgz",
+      "integrity": "sha1-oXGW8zsaz4KGrsbFNyuH+iUgEcI=",
+      "dev": true
+    },
+    "@hapi/rule-no-arrowception": {
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@hapi/rule-no-arrowception/-/rule-no-arrowception-1.1.2.tgz",
+      "integrity": "sha1-knflRNuk6s5hxLo0/HTDNkG4W5k=",
+      "dev": true
+    },
+    "@hapi/rule-no-var": {
+      "version": "1.1.4",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@hapi/rule-no-var/-/rule-no-var-1.1.4.tgz",
+      "integrity": "sha1-Jy4V4X2WnK1+hstfuZOATys/O7o=",
+      "dev": true
+    },
+    "@hapi/rule-scope-start": {
+      "version": "2.2.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@hapi/rule-scope-start/-/rule-scope-start-2.2.0.tgz",
+      "integrity": "sha1-Xcho5CoA0WrZuBquGsDuaCxjsgs=",
+      "dev": true
+    },
+    "@hapi/topo": {
+      "version": "3.1.6",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha1-aNk1+j6uf91asNf5U/MgXYsr/Ck=",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^8.3.0"
+      }
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha1-Olgr21OATGum0UZXnEblITDPSjs=",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.3",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha1-NNxfTKu8cg9OYPdadH5+zWwXW9M=",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha1-ARuSAqcKY2bkNspcBlhEUoqwSXY=",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc=",
+      "dev": true
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-qlmhxuP7xCHgfM0xqUTDDrpSFXU=",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0=",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "12.12.3",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@types/node/-/node-12.12.3.tgz",
+      "integrity": "sha1-6/6DUHrFBrw0hjFKiqOVvmavjSM=",
+      "dev": true
+    },
+    "@wry/equality": {
+      "version": "0.1.9",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/@wry/equality/-/equality-0.1.9.tgz",
+      "integrity": "sha1-sT4Yt6gFPGhYqmyFtUkR+zHjqQk=",
+      "requires": {
+        "tslib": "^1.9.3"
       }
     },
     "ajv": {
@@ -37,27 +723,22 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
-    },
-    "ajv-keywords": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-      "dev": true
     },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -66,40 +747,36 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
-    "ansi-escapes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
-      "dev": true
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
-    },
     "ansi-styles": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+      "version": "3.2.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+      "dev": true,
       "requires": {
-        "color-convert": "1.9.1"
+        "color-convert": "^1.9.0"
       }
     },
     "apollo-link": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.1.0.tgz",
-      "integrity": "sha512-8SP3GtYSMpLa6KJaGfgr3NO/wWmB7xLWASQt3Agf08SljGNx3SOt99Yv5VtM8FPs62BoQmESX73IRmtrD1exdA==",
+      "version": "1.2.13",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/apollo-link/-/apollo-link-1.2.13.tgz",
+      "integrity": "sha1-3/APvxnfzZD928FLaj+adxrKxsQ=",
       "requires": {
-        "@types/zen-observable": "0.5.3",
-        "apollo-utilities": "1.0.8",
-        "zen-observable": "0.7.1"
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.20"
       }
     },
     "apollo-utilities": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.8.tgz",
-      "integrity": "sha512-EvqRJCw5xy2gWeH37toUimbEkmUxronCosBNE4tOCJvZUMLLGB8CuTQ5RsBhKJm+rZ6kwGxV+2uszk14f/P/rA=="
+      "version": "1.3.2",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/apollo-utilities/-/apollo-utilities-1.3.2.tgz",
+      "integrity": "sha1-jL3PiwEvZkzWy1dn9hMPWu2RFck=",
+      "requires": {
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
+      }
     },
     "argparse": {
       "version": "1.0.10",
@@ -107,29 +784,8 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
-    },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "1.0.3"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
     },
     "asn1": {
       "version": "0.2.3",
@@ -143,8 +799,14 @@
     },
     "assertion-error": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k=",
       "dev": true
     },
     "async": {
@@ -168,44 +830,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -218,55 +842,45 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "version": "3.7.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/bluebird/-/bluebird-3.7.1.tgz",
+      "integrity": "sha1-33DjArRx10c0iazyapPWO1P4dN4="
     },
     "boom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.2.0"
-      }
-    },
-    "bossy": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/bossy/-/bossy-3.0.4.tgz",
-      "integrity": "sha1-+a6fJugbQaMY9O4Ng2huSlwlB7k=",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.0",
-        "joi": "10.6.0"
+        "hoek": "4.x.x"
       }
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "caller-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "fill-range": "^7.0.1"
       }
     },
-    "callsites": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
     "camelcase": {
@@ -288,63 +902,39 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chai": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
-      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "version": "4.2.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
-      }
-    },
-    "chai-http": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chai-http/-/chai-http-3.0.0.tgz",
-      "integrity": "sha1-VGDYA24fGhKwtbXL1Snm3B0x60s=",
-      "dev": true,
-      "requires": {
-        "cookiejar": "2.0.6",
-        "is-ip": "1.0.0",
-        "methods": "1.1.2",
-        "qs": "6.5.1",
-        "superagent": "2.3.0"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
       }
     },
     "chalk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+      "version": "2.4.2",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+      "dev": true,
       "requires": {
-        "ansi-styles": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "4.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
-    },
-    "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-      "dev": true
     },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-      "dev": true
-    },
-    "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "cli": {
@@ -354,16 +944,7 @@
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "glob": "7.1.2"
-      }
-    },
-    "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "2.0.0"
+        "glob": "^7.1.1"
       }
     },
     "cli-width": {
@@ -379,8 +960,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -398,204 +979,11 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
-    "code": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/code/-/code-4.1.0.tgz",
-      "integrity": "sha1-IJrRHQWvigwceq9pTZ+k0sfZW4U=",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
-    "codeclimate-test-reporter": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/codeclimate-test-reporter/-/codeclimate-test-reporter-0.5.0.tgz",
-      "integrity": "sha1-k/oGscGOQRc0kSjcTjiq0IBDgo4=",
-      "dev": true,
-      "requires": {
-        "async": "1.5.2",
-        "commander": "2.9.0",
-        "lcov-parse": "0.0.10",
-        "request": "2.79.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.9.0",
-            "is-my-json-valid": "2.17.2",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.79.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.2.1"
-          }
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true
-        }
-      }
-    },
     "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "version": "1.9.3",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -603,26 +991,16 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.0.tgz",
-      "integrity": "sha512-okPpdvdJr6mUGi2XzupC+irQxzwGLVaBzacFC14hjLv8NColXEsxsU+QaeuSSXpQUak5g2K0vQ7WjA1e8svczg=="
-    },
-    "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -631,14 +1009,47 @@
       "dev": true
     },
     "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "version": "1.6.2",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "console-browserify": {
@@ -647,14 +1058,8 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
-    },
-    "cookiejar": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
-      "integrity": "sha1-Cr81atANHFohnYjURRgEbdAmrP4=",
-      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -662,14 +1067,16 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "version": "6.0.5",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
@@ -677,7 +1084,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -685,7 +1092,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -695,7 +1102,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "date-now": {
@@ -703,15 +1110,6 @@
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
-    },
-    "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "requires": {
-        "ms": "2.0.0"
-      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -722,18 +1120,26 @@
     },
     "deep-eql": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/deep-equal/-/deep-equal-1.1.0.tgz",
+      "integrity": "sha1-MQPN+KttMs9KjfeGVFjyuNM/N0U=",
+      "dev": true,
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
     },
     "deep-is": {
       "version": "0.1.3",
@@ -741,19 +1147,13 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "object-keys": "^1.0.12"
       }
     },
     "delayed-stream": {
@@ -766,49 +1166,43 @@
       "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
       "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc="
     },
-    "diff": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
-      "dev": true
-    },
-    "doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8=",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "path-type": "^4.0.0"
       }
     },
     "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "version": "0.2.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/dom-serializer/-/dom-serializer-0.2.1.tgz",
+      "integrity": "sha1-E2UMhQ2v/qNdi2JqTPxNOhdkP9s=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
       },
       "dependencies": {
         "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "version": "2.0.1",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha1-H4vf6R9aeAYydOgDtL3O326U+U0=",
           "dev": true
         },
         "entities": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+          "version": "2.0.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha1-aNYITKsbB5dnVA2A5Wo5tCPkq/Q=",
           "dev": true
         }
       }
     },
     "domelementtype": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "version": "1.3.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8=",
       "dev": true
     },
     "domhandler": {
@@ -817,7 +1211,7 @@
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -826,14 +1220,9 @@
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
-    },
-    "dotenv": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -841,8 +1230,14 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "dev": true
     },
     "entities": {
       "version": "1.0.0",
@@ -853,129 +1248,23 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-    },
-    "eslint": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.7.2.tgz",
-      "integrity": "sha1-/29fUZOEiifum2J74+c/ucteZi4=",
-      "dev": true,
-      "requires": {
-        "ajv": "5.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.3.0",
-        "concat-stream": "1.6.0",
-        "cross-spawn": "5.1.0",
-        "debug": "3.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "3.7.1",
-        "espree": "3.5.3",
-        "esquery": "1.0.0",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "9.18.0",
-        "ignore": "3.3.7",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.5",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.5.0",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.2",
-        "text-table": "0.2.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
-        }
-      }
-    },
-    "eslint-config-hapi": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-hapi/-/eslint-config-hapi-10.1.0.tgz",
-      "integrity": "sha512-tAUedyvZla1qKt6jhOx7mj5tYDVCwdSyImpEK7wk/A/atKUjg18aHUK6Q6qWWM6rq21I1F/A8JAhIpkk0SvFMQ==",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "eslint-plugin-hapi": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-hapi/-/eslint-plugin-hapi-4.1.0.tgz",
-      "integrity": "sha512-z1yUoSWArx6pXaC0FoWRFpqjbHn8QWonJiTVhJmiC14jOAT7FZKdKWCkhM4jQrgrkEK9YEv3p2HuzSf5dtWmuQ==",
+    "eslint-utils": {
+      "version": "1.4.3",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha1-dP7HxU0Hdrb2fgJRBAtYBlZOmB8=",
       "dev": true,
       "requires": {
-        "hapi-capitalize-modules": "1.1.6",
-        "hapi-for-you": "1.0.0",
-        "hapi-no-var": "1.0.1",
-        "hapi-scope-start": "2.1.1",
-        "no-arrowception": "1.0.0"
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
-    "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "dev": true,
-      "requires": {
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
-      }
-    },
-    "espree": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
-      "integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
-      "dev": true,
-      "requires": {
-        "acorn": "5.4.1",
-        "acorn-jsx": "3.0.1"
-      }
+    "eslint-visitor-keys": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha1-4qgs6oT/JGrW+1f5veW0ZiFFnsI=",
+      "dev": true
     },
     "esprima": {
       "version": "4.0.0",
@@ -983,23 +1272,14 @@
       "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
       "dev": true
     },
-    "esquery": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true,
-      "requires": {
-        "estraverse": "4.2.0"
-      }
-    },
     "esrecurse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "^4.1.0",
+        "object-assign": "^4.0.1"
       }
     },
     "estraverse": {
@@ -1025,17 +1305,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
-    "external-editor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
-      "dev": true,
-      "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.19",
-        "tmp": "0.0.33"
-      }
-    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -1045,6 +1314,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
+    "fast-glob": {
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/fast-glob/-/fast-glob-3.1.0.tgz",
+      "integrity": "sha1-dzdafj5vb8mxjwYc3dKLjR7sda4=",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2"
+      }
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -1057,23 +1339,13 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+    "fastq": {
+      "version": "1.6.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/fastq/-/fastq-1.6.0.tgz",
+      "integrity": "sha1-Tsijj0rCXyFJJnOtt+rpz+9H0cI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
-      }
-    },
-    "file-entry-cache": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true,
-      "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "reusify": "^1.0.0"
       }
     },
     "fill-keys": {
@@ -1082,27 +1354,24 @@
       "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
       "dev": true,
       "requires": {
-        "is-object": "1.0.1",
-        "merge-descriptors": "1.0.1"
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
       }
     },
-    "find-rc": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/find-rc/-/find-rc-3.0.1.tgz",
-      "integrity": "sha1-VKQXg3DxC8k3H6jRssKAmir6DM4=",
-      "dev": true
-    },
-    "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "to-regex-range": "^5.0.1"
       }
+    },
+    "flatted": {
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha1-aeV8qo8OrLwoHS4stFjUb9tEngg=",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -1114,16 +1383,10 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
-    },
-    "formidable": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
-      "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak=",
-      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1131,26 +1394,17 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+      "dev": true
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
-    },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "1.0.2"
-      }
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -1163,73 +1417,57 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.5",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/glob/-/glob-7.1.5.tgz",
+      "integrity": "sha1-ZxTGm+4g88PmTE3ZBVU+UytAzcA=",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
-    "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true
-    },
-    "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+    "glob-parent": {
+      "version": "5.1.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha1-X0wdHnSNMM1zrSlEs1d6gbCB6MI=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "is-glob": "^4.0.1"
       }
-    },
-    "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
     },
     "graphql": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.12.3.tgz",
-      "integrity": "sha512-Hn9rdu4zacplKXNrLCvR8YFiTGnbM4Zw/UH8FDmzBDsH7ou40lSNH4tIlsxcYnz2TGNVJCpu1WxCM23yd6kzhA==",
+      "version": "14.5.8",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/graphql/-/graphql-14.5.8.tgz",
+      "integrity": "sha1-UE89MRTLmgo/NZu7zzjZ5b9qazw=",
       "requires": {
-        "iterall": "1.1.3"
+        "iterall": "^1.2.2"
+      },
+      "dependencies": {
+        "iterall": {
+          "version": "1.2.2",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/iterall/-/iterall-1.2.2.tgz",
+          "integrity": "sha1-ktcN64Ao4MOf8xZP2/TYsIgTDNc="
+        }
       }
     },
     "graphql-tools": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-2.21.0.tgz",
-      "integrity": "sha512-AmG4WGdpL1OHwnA20ouP7BVB3KnvUOvsc7+4ULWRzEunyRFUYqxrgnEf20iZnYAha8JCb7AP4WPMwWKmGT91rg==",
+      "version": "4.0.6",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/graphql-tools/-/graphql-tools-4.0.6.tgz",
+      "integrity": "sha1-DnKec9sFrePfEKL5JRG+VElyqEQ=",
       "requires": {
-        "apollo-link": "1.1.0",
-        "apollo-utilities": "1.0.8",
-        "deprecated-decorator": "0.1.6",
-        "iterall": "1.1.3",
-        "uuid": "3.2.1"
+        "apollo-link": "^1.2.3",
+        "apollo-utilities": "^1.0.1",
+        "deprecated-decorator": "^0.1.6",
+        "iterall": "^1.1.3",
+        "uuid": "^3.1.0"
       }
     },
     "handlebars": {
@@ -1238,10 +1476,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "source-map": {
@@ -1250,34 +1488,10 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
-    },
-    "hapi-capitalize-modules": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/hapi-capitalize-modules/-/hapi-capitalize-modules-1.1.6.tgz",
-      "integrity": "sha1-eZEXFBXhXmqjIx5k3ac8gUZmUxg=",
-      "dev": true
-    },
-    "hapi-for-you": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hapi-for-you/-/hapi-for-you-1.0.0.tgz",
-      "integrity": "sha1-02L77o172pwseAHiB+WlzRoLans=",
-      "dev": true
-    },
-    "hapi-no-var": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hapi-no-var/-/hapi-no-var-1.0.1.tgz",
-      "integrity": "sha512-kk2xyyTzI+eQ/oA1rO4eVdCpYsrPHVERHa6+mTHD08XXFLaAkkaEs6reMg1VyqGh2o5xPt//DO4EhCacLx/cRA==",
-      "dev": true
-    },
-    "hapi-scope-start": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/hapi-scope-start/-/hapi-scope-start-2.1.1.tgz",
-      "integrity": "sha1-dJWnJv5yt7yo3izcwdh82M5qtPI=",
-      "dev": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -1289,33 +1503,28 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/has/-/has-1.0.3.tgz",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "function-bind": "^1.1.1"
       }
-    },
-    "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "hoek": {
@@ -1329,37 +1538,11 @@
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.3.0",
-        "domutils": "1.5.1",
-        "entities": "1.0.0",
-        "readable-stream": "1.1.14"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
       }
     },
     "http-signature": {
@@ -1367,22 +1550,28 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
-    "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-      "dev": true
-    },
-    "ignore": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
-      "dev": true
+    "import-fresh": {
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/import-fresh/-/import-fresh-3.1.0.tgz",
+      "integrity": "sha1-bTP6Hc7235MPrgA0RvM0Fa+QURg=",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
+          "dev": true
+        }
+      }
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -1396,106 +1585,55 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "dev": true
     },
-    "inquirer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "3.0.0",
-        "chalk": "2.3.0",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.1.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.5",
-        "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
-      }
-    },
-    "ip-regex": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
-      "integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0=",
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha1-P6+WbHy6D/Q3+zH2JQCC/PBEjPM=",
       "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true,
+      "optional": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
-    "is-ip": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-1.0.0.tgz",
-      "integrity": "sha1-K7aVn3l8zW+f3IEnWLy8h8TFkHQ=",
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
       "dev": true,
       "requires": {
-        "ip-regex": "1.0.3"
+        "is-extglob": "^2.1.1"
       }
     },
-    "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
       "dev": true
-    },
-    "is-my-json-valid": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
-      "dev": true,
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
-      }
     },
     "is-object": {
       "version": "1.0.1",
@@ -1503,47 +1641,20 @@
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
       "dev": true
     },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "1.0.1"
-      }
-    },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "1.0.2"
-      }
-    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
-    },
-    "is-resolvable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-      "dev": true
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1551,15 +1662,9 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
-    "isemail": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-      "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
+      "version": "0.0.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
     "isexe": {
@@ -1573,44 +1678,10 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
-    "items": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
-      "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg=",
-      "dev": true
-    },
     "iterall": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz",
-      "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ=="
-    },
-    "joi": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-      "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.0",
-        "isemail": "2.2.1",
-        "items": "2.1.1",
-        "topo": "2.0.2"
-      }
-    },
-    "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
-    },
-    "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-      "dev": true,
-      "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
-      }
+      "version": "1.2.2",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/iterall/-/iterall-1.2.2.tgz",
+      "integrity": "sha1-ktcN64Ao4MOf8xZP2/TYsIgTDNc="
     },
     "jsbn": {
       "version": "0.1.1",
@@ -1619,19 +1690,27 @@
       "optional": true
     },
     "jshint": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.4.tgz",
-      "integrity": "sha1-XjupeEjVKQJz21FK7kf+JM9ZKTQ=",
+      "version": "2.10.2",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/jshint/-/jshint-2.10.2.tgz",
+      "integrity": "sha1-7WYmxPgiPJjpSq6mJ2dDVCekmj0=",
       "dev": true,
       "requires": {
-        "cli": "1.0.1",
-        "console-browserify": "1.1.0",
-        "exit": "0.1.2",
-        "htmlparser2": "3.8.3",
-        "lodash": "3.7.0",
-        "minimatch": "3.0.4",
-        "shelljs": "0.3.0",
-        "strip-json-comments": "1.0.4"
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "~4.17.11",
+        "minimatch": "~3.0.2",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+          "dev": true
+        }
       }
     },
     "json-schema": {
@@ -1644,31 +1723,16 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
-    "json-stable-stringify": {
+    "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "0.0.0"
-      }
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -1686,45 +1750,9 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
+      "optional": true,
       "requires": {
-        "is-buffer": "1.1.6"
-      }
-    },
-    "lab": {
-      "version": "14.3.2",
-      "resolved": "https://registry.npmjs.org/lab/-/lab-14.3.2.tgz",
-      "integrity": "sha512-Y56h5uJWy1gqGWaiINhOjsxJo1sn13BtefCmFNQKAq8E36+ZHkjV8Vcps+uct87/94mTODrpkmYo3F0Zg0ewHA==",
-      "dev": true,
-      "requires": {
-        "bossy": "3.0.4",
-        "code": "4.1.0",
-        "diff": "3.3.1",
-        "eslint": "4.7.2",
-        "eslint-config-hapi": "10.1.0",
-        "eslint-plugin-hapi": "4.1.0",
-        "espree": "3.5.3",
-        "find-rc": "3.0.1",
-        "handlebars": "4.0.11",
-        "hoek": "4.2.0",
-        "items": "2.1.1",
-        "json-stable-stringify": "1.0.1",
-        "json-stringify-safe": "5.0.1",
-        "mkdirp": "0.5.1",
-        "seedrandom": "2.4.3",
-        "source-map": "0.6.1",
-        "source-map-support": "0.4.18",
-        "supports-color": "4.4.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -1734,42 +1762,37 @@
       "dev": true,
       "optional": true
     },
-    "lcov-parse": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
-      "dev": true
-    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lodash": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
-      "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
+      "version": "4.17.15",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
       "dev": true
     },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "version": "4.1.5",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "merge-descriptors": {
@@ -1778,17 +1801,21 @@
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
-    "methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+    "merge2": {
+      "version": "1.3.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/merge2/-/merge2-1.3.0.tgz",
+      "integrity": "sha1-WzZu6DsvFYLEj4fkfPGpNSEDyoE=",
       "dev": true
     },
-    "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true
+    "micromatch": {
+      "version": "4.0.2",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/micromatch/-/micromatch-4.0.2.tgz",
+      "integrity": "sha1-T8sJmb+fvC/L3SEvbWKbmlbDklk=",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.0.5"
+      }
     },
     "mime-db": {
       "version": "1.30.0",
@@ -1800,22 +1827,16 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "~1.30.0"
       }
-    },
-    "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1839,85 +1860,54 @@
       "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
       "dev": true
     },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
-    },
-    "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "no-arrowception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/no-arrowception/-/no-arrowception-1.0.0.tgz",
-      "integrity": "sha1-W/PpXrnEG1c4SoBTM9qjtzTuMno=",
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
       "dev": true
     },
     "nock": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-9.1.6.tgz",
-      "integrity": "sha512-DuKF+1W/FnMO6MXIGgCIWcM95bETjBbmFdR4v7dAj1zH9a9XhOjAa//PuWh98XIXxcZt7wdiv0JlO0AA0e2kqQ==",
+      "version": "9.6.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/nock/-/nock-9.6.1.tgz",
+      "integrity": "sha1-2W4Jm+m8HQGJp39EkLu7Jlw4G0k=",
       "dev": true,
       "requires": {
-        "chai": "3.5.0",
-        "debug": "2.6.9",
-        "deep-equal": "1.0.1",
-        "json-stringify-safe": "5.0.1",
-        "lodash": "4.17.5",
-        "mkdirp": "0.5.1",
-        "propagate": "0.4.0",
-        "qs": "6.5.1",
-        "semver": "5.5.0"
+        "chai": "^4.1.2",
+        "debug": "^3.1.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.0",
+        "propagate": "^1.0.0",
+        "qs": "^6.5.1",
+        "semver": "^5.5.0"
       },
       "dependencies": {
-        "chai": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-          "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "dev": true,
           "requires": {
-            "assertion-error": "1.1.0",
-            "deep-eql": "0.1.3",
-            "type-detect": "1.0.0"
-          }
-        },
-        "deep-eql": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-          "dev": true,
-          "requires": {
-            "type-detect": "0.1.1"
-          },
-          "dependencies": {
-            "type-detect": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-              "dev": true
-            }
+            "ms": "^2.1.1"
           }
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "version": "4.17.15",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
           "dev": true
         },
-        "type-detect": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         }
       }
@@ -1934,9 +1924,21 @@
       "dev": true
     },
     "object-dig": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/object-dig/-/object-dig-0.1.1.tgz",
-      "integrity": "sha1-/nLnRgxWc5USc7CeXYLjFMLFrNs="
+      "version": "0.1.3",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/object-dig/-/object-dig-0.1.3.tgz",
+      "integrity": "sha1-uuITFQkdbdzl3pvYb5OHGcwrvQc="
+    },
+    "object-is": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/object-is/-/object-is-1.0.1.tgz",
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -1944,16 +1946,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
-      }
-    },
-    "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "1.2.0"
+        "wrappy": "1"
       }
     },
     "optimist": {
@@ -1962,8 +1955,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "wordwrap": {
@@ -1980,12 +1973,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-shim": {
@@ -2000,16 +1993,45 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
+          "dev": true
+        }
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+      "dev": true
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=",
       "dev": true
     },
     "pathval": {
@@ -2023,51 +2045,41 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
-    "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "2.0.4"
-      }
-    },
-    "pluralize": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+    "picomatch": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/picomatch/-/picomatch-2.1.0.tgz",
+      "integrity": "sha1-D9BC9WjQixrZ/y0+wPC/s8uA4Xc=",
       "dev": true
     },
     "pre-commit": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/pre-commit/-/pre-commit-1.2.2.tgz",
       "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "spawn-sync": "1.0.15",
-        "which": "1.2.14"
+        "cross-spawn": "^5.0.1",
+        "spawn-sync": "^1.0.15",
+        "which": "1.2.x"
       },
       "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
         "which": {
           "version": "1.2.14",
           "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
           "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -2079,9 +2091,9 @@
       "dev": true
     },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
       "dev": true
     },
     "progress": {
@@ -2091,20 +2103,20 @@
       "dev": true
     },
     "propagate": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
-      "integrity": "sha1-8/zKCm/gZzanulcpZgaWF8EwtIE=",
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
       "dev": true
     },
     "proxyquire": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.8.0.tgz",
-      "integrity": "sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=",
+      "version": "2.1.3",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha1-IEmn7voQqalTNGoY5UqrK0Jo3zk=",
       "dev": true,
       "requires": {
-        "fill-keys": "1.0.2",
-        "module-not-found-error": "1.0.1",
-        "resolve": "1.1.7"
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
       }
     },
     "pseudomap": {
@@ -2123,97 +2135,114 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-    },
     "ramda": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
-      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
+      "version": "0.26.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha1-jUE1HrgRHFU1Nhf8O7/62OTTXQY="
     },
     "readable-stream": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
-      "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+      "version": "1.1.14",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
       }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+      "integrity": "sha1-azByTjBqJ4M+6xcbZqyIkLo35Bw=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2"
+      }
+    },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha1-jRnTHPYySCtYkEn4KB+T28uk0H8=",
+      "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "request": {
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
+    "request-promise": {
+      "version": "4.2.4",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/request-promise/-/request-promise-4.2.4.tgz",
+      "integrity": "sha1-HF7Q1xRB44rVjHzk6k6lsG1UsxA=",
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha1-M59qq6vK/bMceZ/xWHADNjAdM0Y=",
+      "requires": {
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg="
+        }
       }
     },
     "resolve": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-      "dev": true
-    },
-    "resolve-from": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-      "dev": true
-    },
-    "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "version": "1.12.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha1-P8ZEo1yEpIVUYJ/ybsUrZvpXffY=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "path-parse": "^1.0.6"
       }
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY=",
+      "dev": true
     },
     "right-align": {
       "version": "0.1.3",
@@ -2222,16 +2251,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
-      }
-    },
-    "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2"
+        "align-text": "^0.1.1"
       }
     },
     "run-async": {
@@ -2240,22 +2260,22 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
-    "rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha1-yd06fPn0ssS2JE4XOm7YZuYd1nk=",
       "dev": true
     },
-    "rx-lite-aggregates": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+    "rxjs": {
+      "version": "6.5.3",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha1-UQ4mMX9NuRp+sd532d2boKSJmjo=",
       "dev": true,
       "requires": {
-        "rx-lite": "4.0.8"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -2263,10 +2283,10 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
-    "seedrandom": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
-      "integrity": "sha1-JDhQTa0zkXMUv/GKxNeU8W1qrsw=",
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true
     },
     "semver": {
@@ -2281,7 +2301,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -2302,44 +2322,18 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
-    "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "2.0.0"
-      }
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
+      "dev": true
     },
     "sntp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.2.0"
-      }
-    },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
-    },
-    "source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
+        "hoek": "4.x.x"
       }
     },
     "spawn-sync": {
@@ -2348,8 +2342,8 @@
       "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
-        "os-shim": "0.1.3"
+        "concat-stream": "^1.4.7",
+        "os-shim": "^0.1.2"
       }
     },
     "sprintf-js": {
@@ -2363,129 +2357,51 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
-    "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
-      }
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
+      "version": "0.10.31",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
-    },
     "strip-json-comments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "version": "3.0.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+      "integrity": "sha1-hXE5dakfuHvxswXMp3OV5A0qZKc=",
       "dev": true
     },
-    "superagent": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-2.3.0.tgz",
-      "integrity": "sha1-cDUpoHFOV+EjlZ3e+84ZOy5Q0RU=",
-      "dev": true,
-      "requires": {
-        "component-emitter": "1.2.1",
-        "cookiejar": "2.0.6",
-        "debug": "2.6.9",
-        "extend": "3.0.1",
-        "form-data": "1.0.0-rc4",
-        "formidable": "1.1.1",
-        "methods": "1.1.2",
-        "mime": "1.6.0",
-        "qs": "6.5.1",
-        "readable-stream": "2.3.4"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "1.0.0-rc4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-          "integrity": "sha1-BaxrwiIntD5EYfSIFhVUaZ1Pi14=",
-          "dev": true,
-          "requires": {
-            "async": "1.5.2",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        }
-      }
-    },
     "supports-color": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-      "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-      "requires": {
-        "has-flag": "2.0.0"
-      }
-    },
-    "table": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "version": "5.5.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.3.0",
-        "lodash": "4.17.5",
-        "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "has-flag": "^3.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         }
       }
@@ -2508,16 +2424,16 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
-    "topo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0"
+        "is-number": "^7.0.0"
       }
     },
     "tough-cookie": {
@@ -2525,15 +2441,28 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
+    },
+    "ts-invariant": {
+      "version": "0.4.4",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/ts-invariant/-/ts-invariant-0.4.4.tgz",
+      "integrity": "sha1-l6UjUYaI+TqvrQGw6A64A+sqvYY=",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha1-w8GflZc/sKYpc/sJ2Q2WHuQ+XIo="
     },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -2548,19 +2477,31 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "0.5.2",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/type-fest/-/type-fest-0.5.2.tgz",
+      "integrity": "sha1-1u9CoDVsbNRfSUhcO2KB/BSOSKI=",
       "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.6.4",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/typescript/-/typescript-3.6.4.tgz",
+      "integrity": "sha1-sYdSuzeSvBoCgTNff26/G7/FuR0=",
       "dev": true
     },
     "uglify-js": {
@@ -2570,9 +2511,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "source-map": {
@@ -2591,6 +2532,23 @@
       "dev": true,
       "optional": true
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+          "dev": true
+        }
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2602,24 +2560,36 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha1-4U3jezGm0ZT1aQ1n78Tn9vxqsw4=",
+      "dev": true
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "1.3.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/which/-/which-1.3.1.tgz",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
+    },
+    "will-call": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/will-call/-/will-call-1.0.1.tgz",
+      "integrity": "sha1-mzdWHqcVaquiGyj99jW4D+eL8WY=",
+      "dev": true
     },
     "window-size": {
       "version": "0.1.0",
@@ -2640,21 +2610,6 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
-    "write": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.5.1"
-      }
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
-    },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
@@ -2668,16 +2623,25 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     },
     "zen-observable": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.7.1.tgz",
-      "integrity": "sha512-OI6VMSe0yeqaouIXtedC+F55Sr6r9ppS7+wTbSexkYdHbdt4ctTuPNXP/rwm7GTVI63YBc+EBT0b0tl7YnJLRg=="
+      "version": "0.8.14",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/zen-observable/-/zen-observable-0.8.14.tgz",
+      "integrity": "sha1-0zBYNZ0zW8DbHwr2YVizKHKvO/c="
+    },
+    "zen-observable-ts": {
+      "version": "0.8.20",
+      "resolved": "https://pkgs.dev.azure.com/lgmdevops/_packaging/LGM.npm/npm/registry/zen-observable-ts/-/zen-observable-ts-0.8.20.tgz",
+      "integrity": "sha1-RAkeM10/y8l/ZJfmPn9X1bUWsWM=",
+      "requires": {
+        "tslib": "^1.9.3",
+        "zen-observable": "^0.8.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "index.js"
   ],
   "scripts": {
-    "test": "lab test -v -r console -c",
+    "test": "lab test -v -r console -c -l",
     "lint": "node_modules/.bin/jshint ./src",
     "lab": "lab"
   },
@@ -22,25 +22,20 @@
     "test"
   ],
   "dependencies": {
-    "bluebird": "^3.5.1",
-    "chalk": "^2.3.0",
-    "commander": "^2.14.0",
-    "dotenv": "^4.0.0",
-    "graphql": "^0.12.3",
-    "graphql-tools": "^2.21.0",
-    "object-dig": "^0.1.1",
-    "querystring": "^0.2.0",
-    "ramda": "^0.25.0",
-    "request": "^2.83.0"
+    "bluebird": "^3.7.1",
+    "graphql": "^14.5.8",
+    "graphql-tools": "^4.0.6",
+    "object-dig": "^0.1.3",
+    "ramda": "^0.26.1",
+    "request": "^2.83.0",
+    "request-promise": "^4.2.4"
   },
   "devDependencies": {
-    "chai": "^4.0.2",
-    "chai-http": "^3.0.0",
-    "codeclimate-test-reporter": "^0.5.0",
-    "jshint": "2.9.4",
-    "lab": "^14.1.0",
-    "nock": "^9.1.5",
+    "@hapi/lab": "^21.0.0",
+    "chai": "^4.2.0",
+    "jshint": "^2.10.2",
+    "nock": "^9.6.1",
     "pre-commit": "^1.2.2",
-    "proxyquire": "^1.8.0"
+    "proxyquire": "^2.1.3"
   }
 }

--- a/test/deprecation_spec.js
+++ b/test/deprecation_spec.js
@@ -1,30 +1,39 @@
 /* jslint node: true */
 
-const expect = require('chai').expect,
-      lab = exports.lab = require('lab').script(),
-      describe = lab.describe,
-      it = lab.it,
-      Schema = require('../lib/schema'),
-      Query = require('../lib/query'),
-      schema = Schema.fromFile('test/samples/swapi-schema.graphql'),
-      deprecation = require('../lib/deprecation');
+const expect = require('chai').expect;
+const { describe, it } = exports.lab = require('@hapi/lab').script();
+
+const Schema = require('../lib/schema');
+const Query = require('../lib/query');
+
+const schema = Schema.fromFile('test/samples/swapi-schema.graphql');
+const deprecation = require('../lib/deprecation');
+const badQuery = Query.fromFile('test/samples/deprecation-query.graphql');
+const badQueryNoName = Query.fromFile('test/samples/deprecation-query-no-name.graphql');
+const cleanQuery = Query.fromFile('test/samples/clean-query.graphql');
 
 describe('deprecation', () => {
-
   describe("#reportForQuery", () => {
+    it('should print messages when fields that are deprecated are queried', async () => {
+      const output = await deprecation.reportForQuery(schema, badQuery);
 
-    const badQuery = Query.fromFile('test/samples/deprecation-query.graphql');
-    const cleanQuery = Query.fromFile('test/samples/clean-query.graphql');
-
-    it('should print messages when fields that are deprecated are queried', (done) => {
-      deprecation.reportForQuery(schema, badQuery).then(output => {
-        expect(output).to.contain("has the following deprecation warnings");
-        expect(output).to.contain("The field Film.species is deprecated. Test, use speciesConnection");
-        expect(output).to.contain("The field Film.planets is deprecated. Test, use planetConnection");
-        done();
-      });
+      expect(output).to.contain("has the following deprecation warnings");
+      expect(output).to.contain("The field Film.species is deprecated. Test, use speciesConnection");
+      expect(output).to.contain("The field Film.planets is deprecated. Test, use planetConnection");
     });
 
-  });
+    it('should print messages when fields that are deprecated are queried', async () => {
+      const output = await deprecation.reportForQuery(schema, badQueryNoName);
 
+      expect(output).to.contain("has the following deprecation warnings");
+      expect(output).to.contain("The field Film.species is deprecated. Test, use speciesConnection");
+      expect(output).to.contain("The field Film.planets is deprecated. Test, use planetConnection");
+    });
+
+    it('should print nothing for a query with no deprecations', async () => {
+      const output = await deprecation.reportForQuery(schema, cleanQuery);
+
+      expect(output).to.equal("");
+    });
+  });
 });

--- a/test/operation_name_spec.js
+++ b/test/operation_name_spec.js
@@ -1,34 +1,24 @@
 /* jslint node: true */
 
-const expect = require('chai').expect,
-      lab = exports.lab = require('lab').script(),
-      describe = lab.describe,
-      it = lab.it,
-      Schema = require('../lib/schema'),
-      Query = require('../lib/query'),
-      op = require('../lib/operation_name');
+const expect = require('chai').expect;
+const { describe, it } = exports.lab = require('@hapi/lab').script();
+const Query = require('../lib/query');
+const op = require('../lib/operation_name');
 
 describe('operation_name', () => {
-
   describe('#getOperationNameFromQuery', () => {
-
     const goodQuery = Query.fromFile('test/samples/deprecation-query.graphql');
 
-    it('should be able to parse the operation name from a query', (done) => {
+    it('should be able to parse the operation name from a query', () => {
       expect(op.getOperationNameFromQuery(goodQuery)).to.equal('speciesByFilm');
-      done();
     });
 
-    it('should return null if the query has no name', (done) => {
+    it('should return null if the query has no name', () => {
       expect(op.getOperationNameFromQuery("{ version }")).to.equal(null);
-      done();
     });
 
-    it ('shoul return null if no query was provided', (done) => {
+    it('should return null if no query was provided', () => {
       expect(op.getOperationNameFromQuery(null)).to.equal(null);
-      done();
     });
-
   });
-
 });

--- a/test/samples/bad-query.graphql
+++ b/test/samples/bad-query.graphql
@@ -1,14 +1,11 @@
 query brokenQuery {
-  allFilms {
+  all_films {
     films {
       title
       episodeID {
         blah
       }
-
-
       field_does_not_exist
-
       speciesConnection
     }
   }

--- a/test/samples/deprecation-query-no-name.graphql
+++ b/test/samples/deprecation-query-no-name.graphql
@@ -1,0 +1,11 @@
+query {
+  allFilms {
+    films {
+      title
+      episodeID
+
+      species
+      planets
+    }
+  }
+}

--- a/test/samples/swapi-schema.graphql
+++ b/test/samples/swapi-schema.graphql
@@ -574,6 +574,7 @@ type PlanetsEdge {
 }
 
 type Root {
+  all_films(after: String, first: Int, before: String, last: Int): FilmsConnection @deprecated(reason: "use allFilms")
   allFilms(after: String, first: Int, before: String, last: Int): FilmsConnection
   film(id: ID, filmID: ID): Film
   allPeople(after: String, first: Int, before: String, last: Int): PeopleConnection

--- a/test/schema_spec.js
+++ b/test/schema_spec.js
@@ -1,65 +1,63 @@
 /* jslint node: true */
 
-const expect = require('chai').expect,
-      lab = exports.lab = require('lab').script(),
-      describe = lab.describe,
-      it = lab.it,
-      Schema = require('../lib/schema'),
-      Query = require('../lib/query');
+const expect = require('chai').expect;
+const { describe, it } = exports.lab = require('@hapi/lab').script();
+const nock = require('nock');
+const Schema = require('../lib/schema');
+const mockSchema = require('./samples/swapi-schema.json');
 
 describe('schema', () => {
-
   describe("#fromFile", () => {
-    it('should be able to load a json schema file', (done) => {
+    it('should be able to load a json schema file', () => {
       const s = Schema.fromFile('test/samples/simple-schema.json');
       const x = JSON.parse(JSON.stringify(s))
       expect(x._queryType).to.equal("Query");
-      done();
     });
 
-    it('should be able to load a graphql scheam file', (done) => {
+    it('should be able to load a graphql schema file', () => {
       const s = Schema.fromFile('test/samples/simple-schema.graphql');
       const x = JSON.parse(JSON.stringify(s))
       expect(x._queryType).to.equal("Query");
-      done();
     });
   });
 
   describe('#downloadJSONSchema', () => {
-    it('should be able to download the GRAPHQL_URL schema if no url was provided', (done) => {
-      process.env.GRAPHQL_URL = "http://gdom.graphene-python.org/graphql";
-      Schema.downloadJSONSchema().then(res => {
-        expect(res.__schema.queryType.name).to.equal('Query');
-        done();
-      });
+    const graphHost = nock('http://some-dummy-host.com');
+
+    it('should be able to download the GRAPHQL_URL schema if no url was provided', async () => {
+      graphHost.post('/graphql').reply(200, () => ({ data: mockSchema }));
+
+      process.env.GRAPHQL_URL = "http://some-dummy-host.com/graphql";
+      const res = await Schema.downloadJSONSchema();
+      expect(res.__schema.queryType.name).to.equal('Root');
     });
 
-    it('should be able to download the schema with a provided url', (done) => {
-      Schema.downloadJSONSchema("http://gdom.graphene-python.org/graphql").then(res => {
-        expect(res.__schema.queryType.name).to.equal('Query');
-        done();
-      });
+    it('should be able to download the schema with a provided url', async () => {
+      graphHost.post('/graphql').reply(200, () => ({ data: mockSchema }));
+
+      const res = await Schema.downloadJSONSchema("http://some-dummy-host.com/graphql");
+      expect(res.__schema.queryType.name).to.equal('Root');
     });
   });
 
   describe('#getSchema', () => {
-    it('should download a schema and make it executable', (done) => {
-      Schema.getSchema("http://gdom.graphene-python.org/graphql").then(s => {
-        const x = JSON.parse(JSON.stringify(s))
-        expect(x._queryType).to.equal("Query");
-        done();
-      });
+    const graphHost = nock('http://some-dummy-host.com');
+
+    it('should download a schema and make it executable', async () => {
+      graphHost.post('/graphql').reply(200, () => ({ data: mockSchema }));
+
+      const s = await Schema.getSchema("http://some-dummy-host.com/graphql")
+      const x = JSON.parse(JSON.stringify(s));
+      expect(x._queryType).to.equal("Root");
     });
   });
 
   describe('#jsonToGraphQL', () => {
-    it('should be able to convert a json schema to a graphql idl scheam', (done) => {
-       const jsonSchema = require('./samples/simple-schema.json');
-       const output = Schema.jsonToGraphQL(jsonSchema);
-       expect(output).to.contain('scalar Long');
-       expect(output).to.contain('version: String');
-       done();
+    it('should be able to convert a json schema to a graphql idl schema', async () => {
+      const jsonSchema = require('./samples/simple-schema.json');
+      const output = Schema.jsonToGraphQL(jsonSchema);
+      expect(output).to.contain('scalar Long');
+      expect(output).to.contain('version: String');
     });
   });
-
 });

--- a/test/validation_spec.js
+++ b/test/validation_spec.js
@@ -1,15 +1,12 @@
 /* jslint node: true */
 
-const expect = require('chai').expect,
-      lab = exports.lab = require('lab').script(),
-      describe = lab.describe,
-      it = lab.it,
-      Schema = require('../lib/schema'),
-      Query = require('../lib/query'),
-      validation = require('../lib/validation');
+const expect = require('chai').expect;
+const { describe, it } = exports.lab = require('@hapi/lab').script();
+const Schema = require('../lib/schema');
+const Query = require('../lib/query');
+const validation = require('../lib/validation');
 
 describe('validation', () => {
-
   const schema = Schema.fromFile('test/samples/swapi-schema.graphql');
   const badQuery = Query.fromFile('test/samples/bad-query.graphql');
   const goodQuery = Query.fromFile('test/samples/deprecation-query.graphql');
@@ -17,32 +14,28 @@ describe('validation', () => {
   describe('#getErrors', () => {
     const subject = validation.getErrors;
 
-    it('should find errors in a bad query', (done) => {
+    it('should find errors in a bad query', () => {
       expect(subject(schema, badQuery).length).to.equal(3);
-      done();
     });
 
-    it('should find nothing in a good query', (done) => {
+    it('should find nothing in a good query', () => {
       expect(subject(schema, goodQuery).length).to.equal(0);
-      done();
     });
   });
 
   describe('#reportForQuery', () => {
     const subject = validation.reportForQuery;
 
-    it('should find errors in a bad query', (done) => {
-      const output = subject(schema, badQuery);
+    it('should find errors in a bad query', async () => {
+      const output = await subject(schema, badQuery);
       expect(output).to.include('Field "episodeID" must not have a selection since type "Int" has no subfields');
       expect(output).to.include('Cannot query field "field_does_not_exist" on type "Film"');
       expect(output).to.include('Field "speciesConnection" of type "FilmSpeciesConnection" must have a selection of subfields');
-      done();
     });
 
-    it('should find nothing in a good query', (done) => {
-      const output = subject(schema, goodQuery);
+    it('should find nothing in a good query', async () => {
+      const output = await subject(schema, goodQuery);
       expect(output).to.equal('');
-      done();
     });
   });
 });


### PR DESCRIPTION
* remove no resolver warnings from newer version of GraphQL
* update libraries to remove warnings alerted by github, 
* update some js syntax
* add test for a little more coverage
* remove emoji icon and replace with ascii symbol
* refactor tests to use async instead of done (required for upgrade to lab library)
* fix some typos